### PR TITLE
MAIN-618 - Fork Spreedly gem and add support for stored credentials

### DIFF
--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -186,6 +186,9 @@ module Spreedly
       build_xml_request('transaction') do |doc|
         doc.payment_method_token(payment_method_token)
         add_to_doc(doc, options, :retain_on_success)
+        # include stored_credential params in verify request body
+        add_to_doc(doc, options, :stored_credential_initiator)
+        add_to_doc(doc, options, :stored_credential_reason_type)
         add_extra_options_for_basic_ops(doc, options)
       end
     end

--- a/lib/spreedly/transactions/verification.rb
+++ b/lib/spreedly/transactions/verification.rb
@@ -1,6 +1,7 @@
 module Spreedly
 
   class Verification < GatewayTransaction
+    field :stored_credential_initiator, :stored_credential_reason_type
     attr_reader :payment_method
 
     def initialize(xml_doc)

--- a/test/remote/remote_verify_test.rb
+++ b/test/remote/remote_verify_test.rb
@@ -35,6 +35,22 @@ class RemoteVerifyTest < Test::Unit::TestCase
     assert_equal gateway_token, transaction.gateway_token
   end
 
+  def test_successful_verify_with_stored_credentials
+    gateway_token = @environment.add_gateway(:test).token
+    card_token = create_card_on(@environment).token
+
+    transaction = @environment.verify_on_gateway(
+      gateway_token,
+      card_token,
+      stored_credential_initiator: :merchant,
+      stored_credential_reason_type: :unscheduled
+    )
+
+    assert transaction.succeeded?
+    assert_equal 'merchant', transaction.stored_credential_initiator
+    assert_equal 'unscheduled', transaction.stored_credential_reason_type
+  end
+
   def test_failed_verify
     gateway_token = @environment.add_gateway(:test).token
     card_token = create_failed_card_on(@environment).token


### PR DESCRIPTION
Proposed changes:
- Fork official Spreedly Gem
- Modify verify request to support stored_credential params
- Add test