### PR TITLE
feat: spreedly change

### DIFF
--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -337,7 +337,11 @@ module Spreedly
           text = xml_for_hash_for_braintree(value)
           "<#{key}>#{text}</#{key}>"
         else
-          "<#{key} type='boolean'>#{value}</#{key}>"
+          if [true, false].include? value
+            "<#{key} type='boolean'>#{value}</#{key}>"
+          else
+            "<#{key}>#{value}</#{key}>"
+          end  
         end
       end.join
     end

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -55,9 +55,6 @@ module Spreedly
 
     def verify_on_gateway(gateway_token, payment_method_token, options = {})
       body = verify_body(payment_method_token, options)
-      puts '--------------'
-      puts body
-      puts '---------------'
       api_post(verify_url(gateway_token), body)
     end
 

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -337,7 +337,7 @@ module Spreedly
           text = xml_for_hash_for_braintree(value)
           "<#{key}>#{text}</#{key}>"
         else
-          if [true, false].include? value
+          if [true, false, "true", "false"].include? value
             "<#{key} type='boolean'>#{value}</#{key}>"
           else
             "<#{key}>#{value}</#{key}>"

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -55,6 +55,9 @@ module Spreedly
 
     def verify_on_gateway(gateway_token, payment_method_token, options = {})
       body = verify_body(payment_method_token, options)
+      puts '--------------'
+      puts body
+      puts '---------------'
       api_post(verify_url(gateway_token), body)
     end
 
@@ -314,7 +317,12 @@ module Spreedly
 
     def add_gateway_specific_fields(doc, options)
       return unless options[:gateway_specific_fields].kind_of?(Hash)
-      doc << "<gateway_specific_fields>#{xml_for_hash(options[:gateway_specific_fields])}</gateway_specific_fields>"
+
+      if options[:gateway_specific_fields].key?(:braintree)
+        doc << "<gateway_specific_fields>#{xml_for_hash_for_braintree(options[:gateway_specific_fields])}</gateway_specific_fields>"
+      else
+        doc << "<gateway_specific_fields>#{xml_for_hash(options[:gateway_specific_fields])}</gateway_specific_fields>"
+      end
     end
 
     def add_shipping_address_override(doc, options)
@@ -324,6 +332,17 @@ module Spreedly
           doc.send(k, v)
         end
       end
+    end
+
+    def xml_for_hash_for_braintree(hash)
+      hash.map do |key, value|
+        if value.kind_of?(Hash)
+          text = xml_for_hash_for_braintree(value)
+          "<#{key}>#{text}</#{key}>"
+        else
+          "<#{key} type='boolean'>#{value}</#{key}>"
+        end
+      end.join
     end
 
     def xml_for_hash(hash)


### PR DESCRIPTION
This changes for the `Spreedly`. Currently while we are passing the `boolean` value it automatically converted to the string in the `XML`. So that is causing an issue at `Spreedly` side. To fix that we have passed the `type` = `boolean` to let know the `XML` it is a `boolean` value.